### PR TITLE
lock crystal-sqlite3 at 0.4.0.

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: sqlite_adapter
-version: 0.1.0
+version: 0.1.1
 
 authors:
   - Giorgio Pellero <giorgio@pellero.it>
@@ -9,7 +9,7 @@ license: MIT
 dependencies:
   sqlite3:
     github: manastech/crystal-sqlite3
-    version: ~> 0.2
+    version: 0.4.0
   active_record:
     github: waterlink/active_record.cr
-    version: ~> 0.4
+    version: ~> 1.0

--- a/src/sqlite_adapter.cr
+++ b/src/sqlite_adapter.cr
@@ -21,7 +21,7 @@ module SqliteAdapter
 
     getter table_name, primary_field, fields, types
 
-    def initialize(@table_name, @primary_field, @fields, register = true)
+    def initialize(@table_name : String, @primary_field : String, @fields : Array(String), register = true)
       @db = SQLite3::Database.new(ENV["SQLITE_DB"]? || "data.db")
       @types = Hash(String, String).new
       res = @db.query("PRAGMA table_info(#{@table_name})")


### PR DESCRIPTION
crystal-sqlite3 `0.5.0` not found `SQLite3::Database`.
